### PR TITLE
fix: respect testGap scanner config toggle

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -357,7 +357,9 @@ function buildScannerList(config: OacConfig | null, hasGitHubAuth: boolean): Sca
   const scanners: Scanner[] = [];
   if (config?.discovery.scanners.lint !== false) scanners.push(new LintScanner());
   if (config?.discovery.scanners.todo !== false) scanners.push(new TodoScanner());
-  scanners.push(new TestGapScanner());
+  if (config?.discovery.scanners.testGap !== false) {
+    scanners.push(new TestGapScanner());
+  }
   if (hasGitHubAuth) scanners.push(new GitHubIssuesScanner());
   return scanners;
 }
@@ -1122,8 +1124,9 @@ function selectScannersFromConfig(
     enabled.push("todo");
   }
 
-  // Always include test-gap for autonomous code analysis
-  enabled.push("test-gap");
+  if (config?.discovery.scanners.testGap !== false) {
+    enabled.push("test-gap");
+  }
 
   // Include GitHub issues scanner when a GitHub token is available.
   if (hasGitHubAuth) {

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -287,8 +287,9 @@ function scannersFromConfig(
   if (config.discovery.scanners.todo) {
     configured.push("todo");
   }
-  // Always include test-gap for autonomous discovery
-  configured.push("test-gap");
+  if (config.discovery.scanners.testGap) {
+    configured.push("test-gap");
+  }
   if (hasGitHubAuth) {
     configured.push("github-issues");
   }


### PR DESCRIPTION
## Summary
- Respect discovery.scanners.testGap in oac run/scan scanner selection.
- Restores expected behavior for users disabling test-gap discovery.

## Files changed
- src/cli/commands/run.ts
- src/cli/commands/scan.ts