### PR TITLE
[OAC] test: improve coverage for budget module token counters

### DIFF
--- a/tests/budget/claude-counter.test.ts
+++ b/tests/budget/claude-counter.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const tiktokenMocks = vi.hoisted(() => {
+  const free = vi.fn();
   const encode = vi.fn((text: string) => Array.from({ length: text.length }, (_, index) => index));
   const getEncoding = vi.fn(() => ({
     encode,
+    free,
   }));
 
-  return { encode, getEncoding };
+  return { encode, free, getEncoding };
 });
 
 vi.mock("tiktoken", () => ({
@@ -21,6 +23,7 @@ beforeEach(() => {
   vi.resetModules();
   tiktokenMocks.getEncoding.mockClear();
   tiktokenMocks.encode.mockClear();
+  tiktokenMocks.free.mockClear();
 });
 
 describe("ClaudeTokenCounter", () => {
@@ -31,6 +34,14 @@ describe("ClaudeTokenCounter", () => {
     expect(counter.countTokens("hello")).toBe(5);
     expect(tiktokenMocks.getEncoding).toHaveBeenCalledWith("cl100k_base");
     expect(tiktokenMocks.encode).toHaveBeenCalledWith("hello");
+  });
+
+  it("returns zero for an empty string", async () => {
+    const { ClaudeTokenCounter } = await loadClaudeCounterModule();
+    const counter = new ClaudeTokenCounter();
+
+    expect(counter.countTokens("")).toBe(0);
+    expect(tiktokenMocks.encode).toHaveBeenCalledWith("");
   });
 
   it("getEncoder initializes the encoder once and reuses it", async () => {
@@ -52,5 +63,38 @@ describe("ClaudeTokenCounter", () => {
     expect(counter.invocationOverhead).toBe(1_500);
     expect(counter.maxContextTokens).toBe(200_000);
     expect(counter.encoding).toBe("cl100k_base");
+  });
+});
+
+describe("ClaudeTokenCounter.reset", () => {
+  it("frees the cached encoder", async () => {
+    const { ClaudeTokenCounter } = await loadClaudeCounterModule();
+    const counter = new ClaudeTokenCounter();
+
+    counter.countTokens("init");
+    expect(tiktokenMocks.free).not.toHaveBeenCalled();
+
+    counter.reset();
+    expect(tiktokenMocks.free).toHaveBeenCalledOnce();
+  });
+
+  it("allows the encoder to be re-created on next use", async () => {
+    const { ClaudeTokenCounter } = await loadClaudeCounterModule();
+    const counter = new ClaudeTokenCounter();
+
+    counter.countTokens("before reset");
+    expect(tiktokenMocks.getEncoding).toHaveBeenCalledTimes(1);
+
+    counter.reset();
+    counter.countTokens("after reset");
+    expect(tiktokenMocks.getEncoding).toHaveBeenCalledTimes(2);
+  });
+
+  it("is a no-op when no encoder has been initialized", async () => {
+    const { ClaudeTokenCounter } = await loadClaudeCounterModule();
+    const counter = new ClaudeTokenCounter();
+
+    counter.reset();
+    expect(tiktokenMocks.free).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add `reset()` method tests and edge cases for `ClaudeTokenCounter` (empty string, encoder free/re-create, no-op reset)
- Add `reset()` method tests and edge cases for `CodexTokenCounter` (empty string, encoder free/re-create, no-op reset, encoding re-detection after reset)

Resolves test-gap findings for `src/budget/providers/claude-counter.ts` and `src/budget/providers/codex-counter.ts`.

**Task ID:** 66826baf-9dff-48

## Test plan
- [x] All 17 tests pass (7 claude-counter + 10 codex-counter)
- [x] No changes to source code, only test additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)