### PR TITLE
test: add test coverage for file-filters.ts

### DIFF
--- a/.oac/contributions/2026-03-05-0607-96b333b728a73b7b.json
+++ b/.oac/contributions/2026-03-05-0607-96b333b728a73b7b.json
@@ -1,0 +1,20 @@
+{
+  "version": "1.0",
+  "runId": "e9c717f6-ebac-4f44-97b3-55ff1d9a41cf",
+  "timestamp": "2026-03-05T06:07:46.285Z",
+  "contributor": "jiun",
+  "task": {
+    "id": "96b333b728a73b7b",
+    "title": "Add tests for file-filters.ts",
+    "source": "test-gap",
+    "complexity": "simple"
+  },
+  "execution": {
+    "success": true,
+    "tokensUsed": 285138,
+    "duration": 77.428,
+    "filesChanged": [
+      "tests/core/file-filters.test.ts"
+    ]
+  }
+}

--- a/tests/core/file-filters.test.ts
+++ b/tests/core/file-filters.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { filterRealChanges, isRealFileChange } from "../../src/core/file-filters.js";
+
+describe("isRealFileChange", () => {
+  it("returns true for regular source files", () => {
+    expect(isRealFileChange("src/index.ts")).toBe(true);
+    expect(isRealFileChange("README.md")).toBe(true);
+    expect(isRealFileChange("package.json")).toBe(true);
+  });
+
+  it("returns false for .oac/ metadata files", () => {
+    expect(isRealFileChange(".oac/config.json")).toBe(false);
+    expect(isRealFileChange(".oac/tasks/task-1.json")).toBe(false);
+  });
+
+  it("returns true for files containing .oac in a non-prefix position", () => {
+    expect(isRealFileChange("src/.oac-utils.ts")).toBe(true);
+    expect(isRealFileChange("docs/oac-guide.md")).toBe(true);
+  });
+
+  it("returns true for an empty string", () => {
+    expect(isRealFileChange("")).toBe(true);
+  });
+});
+
+describe("filterRealChanges", () => {
+  it("returns an empty array when given an empty array", () => {
+    expect(filterRealChanges([])).toEqual([]);
+  });
+
+  it("keeps all files when none are metadata", () => {
+    const files = ["src/index.ts", "package.json", "tests/foo.test.ts"];
+    expect(filterRealChanges(files)).toEqual(files);
+  });
+
+  it("removes .oac/ metadata files", () => {
+    const files = ["src/index.ts", ".oac/config.json", "README.md", ".oac/logs/run.log"];
+    expect(filterRealChanges(files)).toEqual(["src/index.ts", "README.md"]);
+  });
+
+  it("returns an empty array when all files are metadata", () => {
+    const files = [".oac/a", ".oac/b/c"];
+    expect(filterRealChanges(files)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Add test coverage for `src/core/file-filters.ts` (`isRealFileChange` and `filterRealChanges`)
- 8 tests covering metadata prefix filtering, edge cases (empty string, non-prefix `.oac`), and mixed inputs
- All tests passing

## Test plan
- [x] `npx vitest run tests/core/file-filters.test.ts` — 8/8 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)